### PR TITLE
Added proxy configuration for GA Connector Docker image

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/build_customization.py
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/build_customization.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dagger import Container
+
+
+async def pre_connector_install(base_image_container: Container) -> Container:
+    """
+    This function will run before the connector installation.
+    This function sets PROXY environment variables of the docker image.
+    The value for Proxy variables may change depending on the environment(staging or prod),
+    so we read its value from environment.
+    """
+    HTTP_PROXY = os.environ["IMAGE_HTTP_PROXY"]
+    HTTPS_PROXY = os.environ["IMAGE_HTTPS_PROXY"]
+
+    return await base_image_container.with_env_variable("HTTP_PROXY", HTTP_PROXY).with_env_variable("HTTPS_PROXY", HTTPS_PROXY)


### PR DESCRIPTION
## What
* Google Analytics 4(GA4) Connector did not work on the Staging environment because of the proxy issue. So, I need to change the docker image for GA4 Connector like we did the same for [Netsuite](https://github.com/canonical/airbyte/pull/3).

## How
GA4 Data API connector does not directly use docker when building images but uses `airbyte-ci`. This is also [suggested by Airbyte](https://docs.airbyte.com/contributing-to-airbyte/resources/qa-checks#python-connectors-must-not-use-a-dockerfile-and-must-declare-their-base-image-in-metadatayaml-file) so that a connector is secure. 

However, Airbyte still [gives an option](https://docs.airbyte.com/connector-development/migration-to-base-image#what-if-my-connector-needs-specific-system-dependencies) to modify docker images when using `airbyte-ci`. 

The solution is adding `build_customization.py` file and adding reading environment variables from os and setting them for the image. Simply the solution is:
```
export IMAGE_HTTP_PROXY=http://squid.internal:3128
export IMAGE_HTTPS_PROXY=http://squid.internal:3128
airbyte-ci connectors --name=source-google-analytics-data-api build
```

We will add this configuration to the Airybte CI/CD, too.
