### PR TITLE
Added proxy config to Marketo connector docker image

### DIFF
--- a/airbyte-integrations/connectors/source-marketo/build_customization.py
+++ b/airbyte-integrations/connectors/source-marketo/build_customization.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dagger import Container
+
+
+async def pre_connector_install(base_image_container: Container) -> Container:
+    """
+    This function will run before the connector installation.
+    This function sets PROXY environment variables of the docker image.
+    The value for Proxy variables may change depending on the environment(staging or prod),
+    so we read its value from environment.
+    """
+    HTTP_PROXY = os.environ["IMAGE_HTTP_PROXY"]
+    HTTPS_PROXY = os.environ["IMAGE_HTTPS_PROXY"]
+
+    return await base_image_container.with_env_variable("HTTP_PROXY", HTTP_PROXY).with_env_variable("HTTPS_PROXY", HTTPS_PROXY)


### PR DESCRIPTION
## What
Marketo Connector did not work on the Staging environment because of the proxy issue. So, I need to change the docker image for Marketo Connector like we did the same for  [Google Analytics Connector](https://github.com/canonical/airbyte/pull/4).

## How

Marketo API connector uses airbyte-ci when building docker images. Airbyte gives an option to modify docker images when using airbyte-ci.

The solution is adding `build_customization.py file` and reading environment variables from `os` and setting them for the image. Simply the solution is:

```
export IMAGE_HTTP_PROXY=http://squid.internal:3128
export IMAGE_HTTPS_PROXY=http://squid.internal:3128
airbyte-ci connectors --name=source-marketo build
```

We will add this configuration to the Airybte CI/CD, too.