### PR TITLE
Added proxy configuration for Google Ads source connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ scan-journal.log
 
 # connectors' cache
 *.sqlite
+
+
+*venv*

--- a/airbyte-integrations/connectors/source-google-ads/build_customization.py
+++ b/airbyte-integrations/connectors/source-google-ads/build_customization.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dagger import Container
+
+
+async def pre_connector_install(base_image_container: Container) -> Container:
+    """
+    This function will run before the connector installation.
+    This function sets PROXY environment variables of the docker image.
+    The value for Proxy variables may change depending on the environment(staging or prod),
+    so we read its value from environment.
+    """
+    HTTP_PROXY = os.environ["IMAGE_HTTP_PROXY"]
+    HTTPS_PROXY = os.environ["IMAGE_HTTPS_PROXY"]
+
+    return await base_image_container.with_env_variable("HTTP_PROXY", HTTP_PROXY).with_env_variable("HTTPS_PROXY", HTTPS_PROXY)


### PR DESCRIPTION
## What
Google Ads Connector did not work in the staging environment because of the proxy issue. So, I need to change the docker image for Google Ads Connector to have a proxy setup.


## How

Google Ads connector uses airbyte-ci when building docker images. Airbyte [gives an option](https://docs.airbyte.com/connector-development/migration-to-base-image#what-if-my-connector-needs-specific-system-dependencies) to modify docker images when using airbyte-ci.

The solution is adding `build_customization.py` file and reading environment variables from os and setting them for the image. Simply the solution is:

```
export IMAGE_HTTP_PROXY=http://squid.internal:3128
export IMAGE_HTTPS_PROXY=http://squid.internal:3128
airbyte-ci connectors --name=source-google-ads build
```
We will add this configuration to the Airybte CI/CD, too.
