### PR TITLE
CSS-13254: update project_category type [jira-connector]

### DIFF
--- a/airbyte-integrations/connectors/source-jira/source_jira/schemas/projects.json
+++ b/airbyte-integrations/connectors/source-jira/source_jira/schemas/projects.json
@@ -81,6 +81,7 @@
     "projectCategory": {
       "description": "The category the project belongs to.",
       "readOnly": true
+      "type": ["object", "null"]
     },
     "projectTypeKey": {
       "type": "string",


### PR DESCRIPTION
Currently the project category is not interpreted as an object and therefore it results in a json field, which is difficult to process.
This ticket mentions the inefficiency of using json: https://warthogs.atlassian.net/browse/CSS-13254

By setting the type of the project category to "object", airbyte would normalize the content of that field.