### PR TITLE
Jira connector for canonical usage

### DIFF
--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - ci-cd-pipeline
 
 jobs:
   build-and-push:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -11,6 +11,7 @@ data:
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   dockerImageTag: 3.5.3
+  canonicalImageTag: 1.0.1
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships


### PR DESCRIPTION
Added canonicalImageTag to jira connector so that we can utilize it in stg & prod Airbyte environments with proxy configurations.