### PR TITLE
[CSS-15965] Fixed Canonical CI pipeline failure of some connectors

### DIFF
--- a/.github/workflows/canonical_ci.yml
+++ b/.github/workflows/canonical_ci.yml
@@ -82,7 +82,8 @@ jobs:
           # return back to root
           cd ../../../
           # Find the latest timestamped report directory inside the CI branch folder
-          REPORT_DIR=$(find airbyte-ci/connectors/pipelines/pipeline_reports/airbyte-ci/connectors/test/manual/"$CI_GIT_BRANCH" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)
+          BRANCH_LOWERCASE="${CI_GIT_BRANCH,,}"
+          REPORT_DIR=$(find airbyte-ci/connectors/pipelines/pipeline_reports/airbyte-ci/connectors/test/manual/"$BRANCH_LOWERCASE" -mindepth 1 -maxdepth 1 -type d | sort | tail -n 1)
           echo "Report dir is $REPORT_DIR"
 
           if [[ -z "$REPORT_DIR" ]]; then


### PR DESCRIPTION
## What
CI Pipelines for [tempo](https://github.com/canonical/airbyte/pull/17) and [smartsheets](https://github.com/canonical/airbyte/pull/16) connectors were failing because the system couldn't find the report path of airbyte-ci. I realized that Airbyte lowers the branch name, which is used as part of the report path. Branch names for these two connectors contain uppercase letters, so CI couldn't find the reports. Please check [here](https://github.com/canonical/airbyte/actions/runs/16228353294/job/45825494642?pr=19#step:4:265) to see the outputs when I did `ls` for my other branch.  

## How
With this fix, I lowercase the branch name.

I tested it with [another PR](https://github.com/canonical/airbyte/pull/19), which is rebased from the Smartsheet connector's development branch (`CSS-7135-source-smartsheets-2-airbyte-latest`).

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
