### PR TITLE
[CSS-15110] Google Ads connector with API v18 is added for Canonical's usage

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -12,6 +12,7 @@ data:
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerImageTag: 3.8.2
+  canonicalImageTag: 1.1.0
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
Adding canonicalImageTag to Google Ads connector v3.8.2 . This version supports Google Ads API v18 and will solve [CSS-15110](https://warthogs.atlassian.net/browse/CSS-15110)