### PR TITLE
[CSS-14534] Upgrade LinkedIn ads connector to 5.5.1 for Canonical's usage

### DIFF
--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,6 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
+  canonicalImageTag: 1.4.0
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads


### PR DESCRIPTION
## What
With this PR, we will upgrade the LinkedIn-ads connector to version 5.5.1 using LinkedIn API v202502. This is needed as the existing LinkedIn-ads connector uses an old version of the LinkedIn API, and we cannot use the connector anymore. 