### PR TITLE
Fixed proxy configuration issue for Linkedin Ads Connector

### DIFF
--- a/.github/scripts/build_custom_docker_image.sh
+++ b/.github/scripts/build_custom_docker_image.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Tag a connector dev image as custom for a given connector and add proxy settings.
+# With that file, the image for the connector will have proxy settings defined.
+
+# Usage: ./build_custom_docker_image.sh <connector-name>
+
+CONNECTOR=$1
+
+echo "🚀 Setting up custom docker image for manifest-only connector $CONNECTOR..."
+
+CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
+DEV_IMAGE="airbyte/$CONNECTOR:dev"
+
+docker build \
+  --build-arg BASE_IMAGE=$DEV_IMAGE \
+  -t "$CUSTOM_IMAGE" \
+  - <<EOF
+FROM $DEV_IMAGE
+ENV HTTP_PROXY=${IMAGE_HTTP_PROXY}
+ENV HTTPS_PROXY=${IMAGE_HTTPS_PROXY}
+EOF
+
+echo "✅ Custom image built for connector $CONNECTOR"

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-    
 
 jobs:
   get_changed_directories_list:

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -94,8 +94,6 @@ jobs:
 
           .github/scripts/generate_build_customizations.sh $CONNECTOR
 
-          cd airbyte-integrations/connectors/$CONNECTOR
-
           # Set proxy environment variables
           export IMAGE_HTTP_PROXY=${{ vars.HTTP_PROXY }}
           export IMAGE_HTTPS_PROXY=${{ vars.HTTPS_PROXY }}
@@ -107,7 +105,7 @@ jobs:
           DEV_IMAGE="airbyte/$CONNECTOR:dev"
           if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "$DEV_IMAGE"; then
             echo "✅ Found built image: $DEV_IMAGE"
-            if grep -q "docker.io/airbyte/source-declarative-manifest" "metadata.yaml"; then
+            if grep -q "docker.io/airbyte/source-declarative-manifest" "$METADATAFILE"; then
               echo "🛠️ Detected manifest-only connector."
               CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
               

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -96,8 +96,6 @@ jobs:
 
           cd airbyte-integrations/connectors/$CONNECTOR
 
-          cat build_customization.py 
-
           # Set proxy environment variables
           export IMAGE_HTTP_PROXY=${{ vars.HTTP_PROXY }}
           export IMAGE_HTTPS_PROXY=${{ vars.HTTPS_PROXY }}
@@ -109,8 +107,26 @@ jobs:
           DEV_IMAGE="airbyte/$CONNECTOR:dev"
           if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "$DEV_IMAGE"; then
             echo "✅ Found built image: $DEV_IMAGE"
-            docker tag "$DEV_IMAGE" "$IMAGE_NAME"
-            docker push "$IMAGE_NAME"
+            if grep -q "docker.io/airbyte/source-declarative-manifest" "$METADATAFILE"; then
+              echo "🛠️ Detected manifest-only connector."
+              CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
+              docker build \
+              --build-arg BASE_IMAGE=$DEV_IMAGE \
+              -t "$CUSTOM_IMAGE" \
+              - <<EOF
+                FROM $DEV_IMAGE
+                ENV HTTP_PROXY=${{ vars.HTTP_PROXY }}
+                ENV HTTPS_PROXY=${{ vars.HTTPS_PROXY }}
+                EOF
+
+              echo "🔄 Tagging and pushing image $CUSTOM_IMAGE to $IMAGE_NAME"
+              docker tag "$CUSTOM_IMAGE" "$IMAGE_NAME"
+              docker push "$IMAGE_NAME"
+            else
+              echo "🔄 Tagging and pushing image $DEV_IMAGE to $IMAGE_NAME"
+              docker tag "$DEV_IMAGE" "$IMAGE_NAME"
+              docker push "$IMAGE_NAME"
+            fi
           else
             echo "❌ Error: Image $DEV_IMAGE was not found after build."
             exit 1

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -110,14 +110,8 @@ jobs:
             if grep -q "docker.io/airbyte/source-declarative-manifest" "$METADATAFILE"; then
               echo "🛠️ Detected manifest-only connector."
               CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
-              docker build \
-              --build-arg BASE_IMAGE=$DEV_IMAGE \
-              -t "$CUSTOM_IMAGE" \
-              - <<EOF
-                FROM $DEV_IMAGE
-                ENV HTTP_PROXY=${{ vars.HTTP_PROXY }}
-                ENV HTTPS_PROXY=${{ vars.HTTPS_PROXY }}
-                EOF
+              
+              .github/scripts/build_custom_docker_image.sh $CONNECTOR
 
               echo "🔄 Tagging and pushing image $CUSTOM_IMAGE to $IMAGE_NAME"
               docker tag "$CUSTOM_IMAGE" "$IMAGE_NAME"

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -96,6 +96,8 @@ jobs:
 
           cd airbyte-integrations/connectors/$CONNECTOR
 
+          cat build_customization.py 
+
           # Set proxy environment variables
           export IMAGE_HTTP_PROXY=${{ vars.HTTP_PROXY }}
           export IMAGE_HTTPS_PROXY=${{ vars.HTTPS_PROXY }}

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -22,8 +22,8 @@ jobs:
         id: detect-changes
         uses: ./.github/actions/detect-changes
         with:
-          base_commit: ${{ github.event.before }}
-          head_commit: ${{ github.sha }}
+          base_commit: ${{ github.event.pull_request.base.sha }}
+          head_commit: ${{ github.event.pull_request.head.sha }}
 
   build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    
 
 jobs:
   get_changed_directories_list:

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
     
 
 jobs:
@@ -22,8 +21,8 @@ jobs:
         id: detect-changes
         uses: ./.github/actions/detect-changes
         with:
-          base_commit: ${{ github.event.pull_request.base.sha }}
-          head_commit: ${{ github.event.pull_request.head.sha }}
+          base_commit: ${{ github.event.before }}
+          head_commit: ${{ github.sha }}
 
   build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -107,7 +107,7 @@ jobs:
           DEV_IMAGE="airbyte/$CONNECTOR:dev"
           if docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "$DEV_IMAGE"; then
             echo "✅ Found built image: $DEV_IMAGE"
-            if grep -q "docker.io/airbyte/source-declarative-manifest" "$METADATAFILE"; then
+            if grep -q "docker.io/airbyte/source-declarative-manifest" "metadata.yaml"; then
               echo "🛠️ Detected manifest-only connector."
               CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
               

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   dockerImageTag: 4.1.2
-  canonicalImageTag: 1.0.3
+  canonicalImageTag: 1.0.4
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   dockerImageTag: 4.1.2
-  canonicalImageTag: 1.0.4
+  canonicalImageTag: 1.0.3
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  canonicalImageTag: 1.4.0
+  canonicalImageTag: 1.4.4
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  canonicalImageTag: 1.4.1
+  canonicalImageTag: 1.4.2
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  canonicalImageTag: 1.4.3
+  canonicalImageTag: 1.4.0
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  canonicalImageTag: 1.4.2
+  canonicalImageTag: 1.4.3
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads

--- a/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-linkedin-ads/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 137ece28-5434-455c-8f34-69dc3782f451
-  canonicalImageTag: 1.4.0
+  canonicalImageTag: 1.4.1
   dockerImageTag: 5.5.1
   dockerRepository: airbyte/source-linkedin-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/linkedin-ads


### PR DESCRIPTION
## What

We need another image of the LinkedIn ads connector because I realized that proxy configurations are not set for the [1.4.0 version of the connector](https://github.com/canonical/airbyte/pkgs/container/airbyte%2Fsource-linkedin-ads/464260689?tag=1.4.0).  After a bit of investigation, I have learnt that airbyte-ci behaves differently for manifest-only connectors and Python connectors. My former solution of using build_customization.py file to add PROXY variables only works for python connectors. Unluckily, there is no way of setting environment variables or manipulating Docker images using airbyte-ci for manifest-only connectors. [Here is the source code ](https://github.com/canonical/airbyte/blob/master/airbyte-ci/connectors/pipelines/pipelines/airbyte_ci/connectors/build_image/steps/manifest_only_connectors.py)for building manifest-only images. 

## How
As a solution, we will manipulate the Docker images generated by `airbyte-ci`. I created a script to add environment variables to the `dev` image created by airbyte-ci. I did this just for the manifest-only connectors thanks to the fact that Airbyte uses different base images for manifest-only and Python connectors.

## Tests
I have tested it for both manifest-only and Python connectors.  
* As a Python connector, I have chosen the Jira connector and run the CD pipeline for it. [Here](https://github.com/canonical/airbyte/pkgs/container/airbyte%2Fsource-jira/464685935?tag=1.0.4) is the image.
* As a manifest-only connector, I have chosen LinkedIn Ads connector, and [here](https://github.com/canonical/airbyte/pkgs/container/airbyte%2Fsource-linkedin-ads/464690538?tag=1.4.4) is the image CD pipeline generated.