### PR TITLE
Fixed proxy configuration issue for Google Ads Connector

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerImageTag: 3.8.2
-  canonicalImageTag: 1.1.0
+  canonicalImageTag: 1.1.1
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads


### PR DESCRIPTION
We need another image of the Google ads connector because the `HTTPS_PROXY` variable of the repository contained a newline character. I deleted the character, and this PR will generate another image.
