### PR TITLE
joins all streams' start date into one

### DIFF
--- a/airbyte-integrations/connectors/source-tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/manifest.yaml
@@ -151,7 +151,7 @@ definitions:
         datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config['worklogs_start_date'] }}"
+          datetime: "{{ config['start_date'] }}"
           datetime_format: "%Y-%m-%d"
         start_time_option:
           type: RequestOption
@@ -266,7 +266,7 @@ definitions:
         datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config['plans_start_date'] }}"
+          datetime: "{{ config['start_date'] }}"
           datetime_format: "%Y-%m-%d"
         start_time_option:
           type: RequestOption
@@ -352,7 +352,7 @@ definitions:
         datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
-          datetime: "{{ config['timesheet_approvals_start_date'] }}"
+          datetime: "{{ config['start_date'] }}"
           datetime_format: "%Y-%m-%d"
         start_time_option:
           type: RequestOption
@@ -522,33 +522,12 @@ spec:
         order: 0
         title: API token
         airbyte_secret: true
-      plans_start_date:
+      start_date:
         type: string
-        description: >-
-          Required if Plans stream is enabled. - Ignores all plans prior to this
-          date.
-        title: Plans start date
-        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
+        title: Start date
         format: date
+        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
         order: 1
-      worklogs_start_date:
-        type: string
-        description: >-
-          Required if Worklogs stream is enabled. - Ignores all worklogs prior
-          to this date
-        title: Worklogs start date
-        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
-        format: date
-        order: 2
-      timesheet_approvals_start_date:
-        type: string
-        description: >-
-          Required if Timesheet-approvals stream is enabled. - Ignores all
-          timesheet-approvals prior to this date
-        title: Timesheet-Approvals start date
-        pattern: ^[0-9]{4}-[0-9]{2}-[0-9]{2}$
-        format: date
-        order: 3
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-tempo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tempo/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorType: source
   definitionId: d1aa448b-7c54-498e-ad95-263cbebcd2db
   dockerImageTag: 0.4.25
-  canonicalImageTag: 1.0.0
+  canonicalImageTag: 1.0.1
   dockerRepository: airbyte/source-tempo
   documentationUrl: https://docs.airbyte.com/integrations/sources/tempo
   githubIssueLabel: source-tempo

--- a/airbyte-integrations/connectors/source-tempo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tempo/metadata.yaml
@@ -9,7 +9,7 @@ data:
   connectorType: source
   definitionId: d1aa448b-7c54-498e-ad95-263cbebcd2db
   dockerImageTag: 0.4.25
-  canonicalImageTag: 1.0.1
+  canonicalImageTag: 1.1.0
   dockerRepository: airbyte/source-tempo
   documentationUrl: https://docs.airbyte.com/integrations/sources/tempo
   githubIssueLabel: source-tempo


### PR DESCRIPTION
This PR joins all start date inputs into one. Previously, each stream that expected a start date input had it's own separate variable. - The EPM team requested that we sync different data from different dates. 

However, to avoid introducing more variables when adding more streams and increase complexity, it should be one start date for all streams. - Data can be filtered by date when querying the destination database.