### PR TITLE
[CSS-16810] Updated Google Ads connector so that we use Ads API v20

### DIFF
--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -12,7 +12,7 @@ data:
   connectorType: source
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerImageTag: "4.1.0-rc.1"
-  canonicalImageTag: 1.1.1
+  canonicalImageTag: 1.2.0
   dockerRepository: airbyte/source-google-ads
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   githubIssueLabel: source-google-ads


### PR DESCRIPTION
I have rebased master to the Airbyte upstream main branch so that we can upgrade to the latest version of the Google Ads connector, which supports Google Ads API v20.