### PR TITLE
Feat: Add canonical image tag

### DIFF
--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -22,6 +22,7 @@ data:
   connectorType: source
   definitionId: bfd1ddf8-ae8a-4620-b1d7-55597d2ba08c
   dockerImageTag: 0.4.4
+  canonicalImageTag: 1.0.0
   dockerRepository: airbyte/source-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/sources/bigquery
   githubIssueLabel: source-bigquery


### PR DESCRIPTION
## Description
This PR adds an image tag to the BigQuery Airbyte source to prompt creation of the image under Canonical's GHCR. 