### PR TITLE
Created an action to manually build connecter images with proxy configuration

### DIFF
--- a/.github/scripts/build_custom_docker_image.sh
+++ b/.github/scripts/build_custom_docker_image.sh
@@ -1,23 +1,21 @@
 #!/bin/bash
-# Tag a connector dev image as custom for a given connector and add proxy settings.
+# Build a custom docker image from another docker image (typically a dev image).
 # With that file, the image for the connector will have proxy settings defined.
 
-# Usage: ./build_custom_docker_image.sh <connector-name>
+# Usage: ./build_custom_docker_image.sh <custom-image-tag> <dev-image-tag>
 
-CONNECTOR=$1
+CUSTOM_IMAGE=$1
+BASE_IMAGE=$2
 
-echo "🚀 Setting up custom docker image for manifest-only connector $CONNECTOR..."
-
-CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
-DEV_IMAGE="airbyte/$CONNECTOR:dev"
+echo "🚀 Setting up custom docker image: $CUSTOM_IMAGE from base image: $BASE_IMAGE..."
 
 docker build \
-  --build-arg BASE_IMAGE=$DEV_IMAGE \
+  --build-arg BASE_IMAGE=$BASE_IMAGE \
   -t "$CUSTOM_IMAGE" \
   - <<EOF
-FROM $DEV_IMAGE
+FROM $BASE_IMAGE
 ENV HTTP_PROXY=${IMAGE_HTTP_PROXY}
 ENV HTTPS_PROXY=${IMAGE_HTTPS_PROXY}
 EOF
 
-echo "✅ Custom image built for connector $CONNECTOR"
+echo "✅ Custom image built: $CUSTOM_IMAGE from $BASE_IMAGE"

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -21,8 +21,8 @@ jobs:
         id: detect-changes
         uses: ./.github/actions/detect-changes
         with:
-          base_commit: ${{ github.event.before }}
-          head_commit: ${{ github.sha }}
+          base_commit: ${{ github.event.pull_request.base.sha }}
+          head_commit: ${{ github.event.pull_request.head.sha }}
 
   build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -1,6 +1,7 @@
 name: Canonical CD
 
 on:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -108,7 +108,7 @@ jobs:
               echo "🛠️ Detected manifest-only connector."
               CUSTOM_IMAGE="airbyte/$CONNECTOR:custom"
               
-              .github/scripts/build_custom_docker_image.sh $CONNECTOR
+              .github/scripts/build_custom_docker_image.sh "$CUSTOM_IMAGE" "$DEV_IMAGE"
 
               echo "🔄 Tagging and pushing image $CUSTOM_IMAGE to $IMAGE_NAME"
               docker tag "$CUSTOM_IMAGE" "$IMAGE_NAME"

--- a/.github/workflows/canonical_generate_image.yml
+++ b/.github/workflows/canonical_generate_image.yml
@@ -1,0 +1,65 @@
+name: Canonical Generate Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      connector_name:
+        description: "Airbyte connector name (e.g. source-bigquery)"
+        required: true
+        type: string
+      image_version:
+        description: "Canonical image version (e.g. 1.0.0)"
+        required: true
+        type: string
+
+jobs:
+  generate_and_push_image:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Read dockerImageTag from metadata.yaml
+        id: get_tag
+        run: |
+          METADATA_FILE="airbyte-integrations/connectors/${{ github.event.inputs.connector_name }}/metadata.yaml"
+          if [ ! -f "$METADATA_FILE" ]; then
+            echo "❌ metadata.yaml not found for connector ${{ github.event.inputs.connector_name }}"
+            exit 1
+          fi
+          DOCKER_IMAGE_TAG=$(grep 'dockerImageTag:' "$METADATA_FILE" | head -n1 | cut -d':' -f2 | tr -d ' "')
+          if [ -z "$DOCKER_IMAGE_TAG" ]; then
+            echo "❌ dockerImageTag not found in $METADATA_FILE"
+            exit 1
+          fi
+          echo "docker_image_tag=$DOCKER_IMAGE_TAG" >> $GITHUB_OUTPUT
+
+      - name: Build Docker image with proxy
+        env:
+          CONNECTOR_NAME: ${{ github.event.inputs.connector_name }}
+          IMAGE_VERSION: ${{ github.event.inputs.image_version }}
+          DOCKER_IMAGE_TAG: ${{ steps.get_tag.outputs.docker_image_tag }}
+          IMAGE_HTTP_PROXY: ${{ vars.HTTP_PROXY }}
+          IMAGE_HTTPS_PROXY: ${{ vars.HTTPS_PROXY }}
+        run: |
+          IMAGE_NAME="ghcr.io/canonical/airbyte/${CONNECTOR_NAME}:${IMAGE_VERSION}"
+          DEV_IMAGE="airbyte/${CONNECTOR_NAME}:${DOCKER_IMAGE_TAG}"
+          echo "Building image $IMAGE_NAME from dev image $DEV_IMAGE using build_custom_docker_image.sh"
+          .github/scripts/build_custom_docker_image.sh "$IMAGE_NAME" "$DEV_IMAGE"
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push Docker image to GHCR
+        env:
+          CONNECTOR_NAME: ${{ github.event.inputs.connector_name }}
+          IMAGE_VERSION: ${{ github.event.inputs.image_version }}
+        run: |
+          IMAGE_NAME="ghcr.io/canonical/airbyte/${CONNECTOR_NAME}:${IMAGE_VERSION}"
+          echo "Pushing $IMAGE_NAME"
+          docker push "$IMAGE_NAME"
+          echo "✅ Successfully pushed $IMAGE_NAME"

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 200
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
+    baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 200
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.1@sha256:ec89bd1a89e825514dd2fc8730ba299a3ae1544580a078df0e35c5202c2085b3
+    baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -3,7 +3,7 @@ data:
     ql: 200
     sl: 100
   connectorBuildOptions:
-    baseImage: docker.io/airbyte/java-connector-base:2.0.3@sha256:119b8506bca069bbc8357a275936c7e2b0994e6947b81f1bf8d6ce9e16db7d47
+    baseImage: docker.io/airbyte/java-connector-base:2.0.0@sha256:5a1a21c75c5e1282606de9fa539ba136520abe2fbd013058e988bb0297a9f454
   connectorSubtype: database
   connectorTestSuitesOptions:
     - suite: unitTests

--- a/airbyte-integrations/connectors/source-bigquery/metadata.yaml
+++ b/airbyte-integrations/connectors/source-bigquery/metadata.yaml
@@ -22,6 +22,7 @@ data:
   connectorType: source
   definitionId: bfd1ddf8-ae8a-4620-b1d7-55597d2ba08c
   dockerImageTag: 0.4.4
+  canonicalImageTag: 1.0.0
   dockerRepository: airbyte/source-bigquery
   documentationUrl: https://docs.airbyte.com/integrations/sources/bigquery
   githubIssueLabel: source-bigquery


### PR DESCRIPTION
## What
This PR adds a new github action. This new action will be triggered manually. The idea is to add HTTP proxy variables to an existing Airbyte connector image. With this approach, we do not have to create PRs every time we need to use an existing Airbyte image. 

## How
By using `docker build .... FROM ...` syntax, we are adding new HTTP proxy env environments to existing connector docker image.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
