### PR TITLE
[CSS-17484] Add `schemeId` to `holiday-scheme-members`, and uses `updatedAt` as cursor for the `plans` stream

### DIFF
--- a/airbyte-integrations/connectors/source-tempo/manifest.yaml
+++ b/airbyte-integrations/connectors/source-tempo/manifest.yaml
@@ -227,7 +227,8 @@ definitions:
           path: plans
           http_method: GET
           request_parameters:
-            to: "{{ day_delta(365, format=\"%Y-%m-%d\") }}"
+            from: "{{ config['start_date'] }}"
+            to: "\"2100-01-01\""
           error_handler:
             type: CompositeErrorHandler
             error_handlers:
@@ -260,9 +261,9 @@ definitions:
           type: JsonDecoder
       incremental_sync:
         type: DatetimeBasedCursor
-        cursor_field: startDate
+        cursor_field: updatedAt
         cursor_datetime_formats:
-          - "%Y-%m-%d"
+          - "%Y-%m-%dT%H:%M:%SZ"
         datetime_format: "%Y-%m-%d"
         start_datetime:
           type: MinMaxDatetime
@@ -271,7 +272,7 @@ definitions:
         start_time_option:
           type: RequestOption
           inject_into: request_parameter
-          field_name: from
+          field_name: updatedFrom
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -483,6 +484,13 @@ definitions:
                 $ref: "#/definitions/streams/holiday-schemes"
         decoder:
           type: JsonDecoder
+      transformations:
+        - type: AddFields
+          fields:
+            - type: AddedFieldDefinition
+              path:
+                - schemeId
+              value: "{{ stream_slice['scheme_id'] }}"
       schema_loader:
         type: InlineSchemaLoader
         schema:
@@ -547,18 +555,18 @@ metadata:
       streamHash: 3a62fd72589bb9e60684fd118ca8cb99bc0257e8
       hasResponse: true
       responsesAreSuccessful: true
-      hasRecords: false
+      hasRecords: true
       primaryKeysArePresent: true
       primaryKeysAreUnique: true
     customers:
       streamHash: aab3b81e1940147af3026eb559e3004fa33b3e47
       hasResponse: true
       responsesAreSuccessful: true
-      hasRecords: false
+      hasRecords: true
       primaryKeysArePresent: true
       primaryKeysAreUnique: true
     worklogs:
-      streamHash: 4306459a64274f9c2e56c35696c76fc8e2cdbdf0
+      streamHash: d7844405a81bc051c3079847f9fc3566a52237c8
       hasResponse: true
       responsesAreSuccessful: true
       hasRecords: true
@@ -572,7 +580,7 @@ metadata:
       primaryKeysArePresent: true
       primaryKeysAreUnique: true
     plans:
-      streamHash: b0c80df0b85c6842d4811bb787729fe40041fc03
+      streamHash: 097d557c75c082d9e6276ad024564c2401936dd0
       hasResponse: true
       responsesAreSuccessful: true
       hasRecords: true
@@ -607,12 +615,12 @@ metadata:
       primaryKeysArePresent: true
       responsesAreSuccessful: true
     holiday-scheme-members:
-      hasRecords: true
-      streamHash: 287a31ec234aa16ba1536fb78bf71b8527792126
+      streamHash: 5247dbee9c28e2f3bd41b4ea4ba93d78254064b8
       hasResponse: true
-      primaryKeysAreUnique: true
-      primaryKeysArePresent: true
       responsesAreSuccessful: true
+      hasRecords: true
+      primaryKeysArePresent: true
+      primaryKeysAreUnique: true
   assist: {}
 
 schemas:
@@ -922,7 +930,9 @@ schemas:
           - string
           - "null"
       startDate:
-        type: string
+        type:
+          - string
+          - "null"
       startTime:
         type:
           - string
@@ -940,12 +950,10 @@ schemas:
           - number
           - "null"
       updatedAt:
-        type:
-          - string
-          - "null"
+        type: string
     required:
       - id
-      - startDate
+      - updatedAt
   teams:
     type: object
     $schema: http://json-schema.org/schema#
@@ -1231,6 +1239,10 @@ schemas:
     properties:
       accountId:
         type: string
+      schemeId:
+        type:
+          - number
+          - "null"
       self:
         type:
           - string

--- a/airbyte-integrations/connectors/source-tempo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-tempo/metadata.yaml
@@ -8,8 +8,8 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: d1aa448b-7c54-498e-ad95-263cbebcd2db
-  dockerImageTag: 0.4.29
-  canonicalImageTag: 1.1.0
+  dockerImageTag: 0.4.30
+  canonicalImageTag: 1.1.1
   dockerRepository: airbyte/source-tempo
   documentationUrl: https://docs.airbyte.com/integrations/sources/tempo
   githubIssueLabel: source-tempo


### PR DESCRIPTION
This PR adds a transformation to add a new field `schemeId` to the `holiday-scheme-members` stream, it also changes the cursor for the `plans` stream.

The Tempo API plans endpoint expects a mandatory `from` and `to` query parameters. Initially EPM requested that we set `from` to a year prior and `to` for a year ahead of the sync date (today). However, to make it more versatile, we will use the `start_date` variable for the `from` parameter and a hardcoded value of "2100-01-01" for the `to` parameter, and then use the `updatedAt` value as a cursor for incremental sync.

Fixes [CSS-17484](https://warthogs.atlassian.net/browse/CSS-17484).

[CSS-17484]: https://warthogs.atlassian.net/browse/CSS-17484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ