### PR TITLE
Fixed the CD pipeline by reverting the change made for testing

### DIFF
--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -20,8 +20,8 @@ jobs:
         id: detect-changes
         uses: ./.github/actions/detect-changes
         with:
-          base_commit: ${{ github.event.pull_request.base.sha }}
-          head_commit: ${{ github.event.pull_request.head.sha }}
+          base_commit: ${{ github.event.before }}
+          head_commit: ${{ github.sha }}
 
   build_and_push:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
<!--
* Describe what the change is solving. Link all GitHub issues related to this change.
-->
I have mistakenly left base and head commits to use pull_request event but when we commit to master there is not pull request. This PR reverts the [last change](https://github.com/canonical/airbyte/pull/32) I made. 

## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
