### PR TITLE
[CSS-16015] Updating facebook marketing connector

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
+++ b/airbyte-integrations/connectors/source-facebook-marketing/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: e7778cfc-e97c-4458-9ecb-b4f2bba8946c
   dockerImageTag: 4.0.1
-  canonicalImageTag: 1.2.0
+  canonicalImageTag: 4.0.1-canonical-1.1.0
   dockerRepository: airbyte/source-facebook-marketing
   documentationUrl: https://docs.airbyte.com/integrations/sources/facebook-marketing
   githubIssueLabel: source-facebook-marketing


### PR DESCRIPTION
## What

* In order to use the latest Facebook Marketing APIs, we needed to update the airbyte connector. This PR addresses this issue.
* The current version that we were using (v21) is being deprecated and hence we need to upgrade the connector in order to use version v23.

