### PR TITLE
[CSS-17410] Removed user stream from check list of Jira connector

### DIFF
--- a/airbyte-integrations/connectors/source-jira/manifest.yaml
+++ b/airbyte-integrations/connectors/source-jira/manifest.yaml
@@ -14625,8 +14625,8 @@ check:
   type: CheckStream
   stream_names:
   - projects
-  - users
   - issues
+# Removed user stream from check list because it requires admin permissions to access
 
 # Defining a value here is difficult because the Jira API documentation mentions "REST API rate limits are not published because the computation logic is evolving continuously to maximize reliability and performance for customers" regarding the API budget. Hence, we will need to empirically validate the values that are set here.
 concurrency_level:

--- a/airbyte-integrations/connectors/source-jira/metadata.yaml
+++ b/airbyte-integrations/connectors/source-jira/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 68e63de2-bb83-4c7e-93fa-a8a9051e3993
   dockerImageTag: 4.3.1
-  canonicalImageTag: 4.3.1-canonical-1.1.0
+  canonicalImageTag: 4.3.1-canonical-1.1.1
   dockerRepository: airbyte/source-jira
   documentationUrl: https://docs.airbyte.com/integrations/sources/jira
   erdUrl: https://dbdocs.io/airbyteio/source-jira?view=relationships


### PR DESCRIPTION
## What
In the latest version of the Jira connector, the connector checks three streams to ensure that it can access the specified Jira API. However, accessing the `User` stream requires admin-level permission for the integration user in Canonical. Thus, we need to remove it. 

## How
Removed the `User` stream from check list.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
