### PR TITLE
Update Salesloft connector input

### DIFF
--- a/airbyte-integrations/connectors/source-salesloft/manifest.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/manifest.yaml
@@ -1427,6 +1427,8 @@ definitions:
           $ref: "#/definitions/base_requester"
           path: /activity_histories
           http_method: GET
+          request_parameters:
+            type: "{{ config['activity_histories_action_type'] }}"
         record_selector:
           type: RecordSelector
           extractor:
@@ -1792,6 +1794,10 @@ spec:
         order: 1
         examples:
           - "2020-11-16T00:00:00Z"
+      activity_histories_action_type:
+        type: string
+        title: Activity Histories Action Type
+        order: 2
     additionalProperties: true
 
 metadata:

--- a/airbyte-integrations/connectors/source-salesloft/metadata.yaml
+++ b/airbyte-integrations/connectors/source-salesloft/metadata.yaml
@@ -22,7 +22,7 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: 41991d12-d4b5-439e-afd0-260a31d4c53f
-  canonicalImageTag: 1.5.2-canonical-1.2.0
+  canonicalImageTag: 1.5.2-canonical-1.2.1
   dockerImageTag: 1.5.2
   dockerRepository: airbyte/source-salesloft
   githubIssueLabel: source-salesloft


### PR DESCRIPTION
This PR adds a `activity_histories_action_type` input parameter to the Salesloft source connector, to help filter on the volume of data being ingested for the `activity_histories` stream.