### PR TITLE
chore: add missing permissions

### DIFF
--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.get_changed_directories_list.outputs.connectors_list_json != '[]'
     needs: [get_changed_directories_list]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         dir: ${{ fromJson(needs.get_changed_directories_list.outputs.connectors_list_json) }}

--- a/.github/workflows/canonical_generate_image.yml
+++ b/.github/workflows/canonical_generate_image.yml
@@ -51,6 +51,9 @@ jobs:
     runs-on: ubuntu-latest
     if: needs.resolve_connectors.outputs.connectors_list_json != '[]'
     needs: [resolve_connectors]
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         dir: ${{ fromJson(needs.resolve_connectors.outputs.connectors_list_json) }}


### PR DESCRIPTION
## What

The build-and-push step is [failing](https://github.com/canonical/airbyte/actions/runs/26808988068/job/79042664541#step:3:629) at docker push with:
```
denied: installation not allowed to write organization package
```

The push authenticates to GHCR using the workflow's `GITHUB_TOKEN`. Since the workflow declares no permissions block, the token fell back to the repo/org default (read-only) without the scope to write packages. The image built fine, but the final push to `ghcr.io/<org>/...` was rejected.

## How
Add a permissions block granting `packages: write` to the `generate_and_push_image` job in `canonical_generate_image.yml`.

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
