### PR TITLE
Add GRPc Proxy configuration to CD pipeline

### DIFF
--- a/.github/actions/canonical-image-build-push/action.yml
+++ b/.github/actions/canonical-image-build-push/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: "Optional HTTPS proxy passed as a build arg and baked into the manifest-only proxy wrapper."
     required: false
     default: ""
+  grpc-proxy:
+    description: "Optional gRPC proxy passed as a build arg (sets grpc_proxy env var in the image)."
+    required: false
+    default: ""
+  grpc-proxy-exp:
+    description: "Optional gRPC experimental proxy passed as a build arg (sets GRPC_PROXY_EXP env var in the image)."
+    required: false
+    default: ""
 
 outputs:
   image-name:
@@ -91,6 +99,8 @@ runs:
         IMAGE_VERSION_OVERRIDE: ${{ inputs.image-version-override }}
         IMAGE_HTTP_PROXY: ${{ inputs.http-proxy }}
         IMAGE_HTTPS_PROXY: ${{ inputs.https-proxy }}
+        IMAGE_GRPC_PROXY: ${{ inputs.grpc-proxy }}
+        IMAGE_GRPC_PROXY_EXP: ${{ inputs.grpc-proxy-exp }}
         DRY_RUN: ${{ inputs.dry-run }}
       run: |
         set -euo pipefail
@@ -130,6 +140,10 @@ runs:
           --build-arg CONNECTOR_NAME="$CONNECTOR" \
           --build-arg HTTP_PROXY="$IMAGE_HTTP_PROXY" \
           --build-arg HTTPS_PROXY="$IMAGE_HTTPS_PROXY" \
+          --build-arg http_proxy="$IMAGE_HTTP_PROXY" \
+          --build-arg https_proxy="$IMAGE_HTTPS_PROXY" \
+          --build-arg grpc_proxy="$IMAGE_GRPC_PROXY" \
+          --build-arg GRPC_PROXY_EXP="$IMAGE_GRPC_PROXY_EXP" \
           "airbyte-integrations/connectors/$CONNECTOR"
 
         if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "$DEV_IMAGE"; then

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -46,3 +46,5 @@ jobs:
           connector: ${{ matrix.dir }}
           http-proxy: ${{ vars.HTTP_PROXY }}
           https-proxy: ${{ vars.HTTPS_PROXY }}
+          grpc-proxy: ${{ vars.GRPC_PROXY }}
+          grpc-proxy-exp: ${{ vars.GRPC_PROXY_EXP }}

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -13,6 +13,7 @@ data:
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerImageTag: 4.2.6-rc.2
   dockerRepository: airbyte/source-google-ads
+  canonicalImageTag: 4.2.6-canonical-1.3.0
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:
     - title: Release notes


### PR DESCRIPTION
## What
Google Ads connector uses the Google Ads Python client, which communicates with Google Ads through gRPC.

Before the recent Kubernetes/network changes, the connector was still able to reach `googleads.googleapis.com:443` directly from the Airbyte workload pods. Because direct egress worked, the gRPC client did not need to rely on proxy-specific environment variables.

After the Kubernetes/network changes, direct egress from Airbyte workload pods no longer works reliably. We confirmed this by testing from the pod: direct curl to `googleads.googleapis.com:443` times out, while the same request works when routed through `squid.internal:3128`.

The connector already had HTTP_PROXY and HTTPS_PROXY set, but gRPC C-Core, which is used underneath the Python Google Ads client, does not rely on those uppercase variables in the same way as normal HTTP clients. gRPC’s proxy mapper checks gRPC/lowercase proxy variables such as grpc_proxy, https_proxy, and http_proxy for HTTP CONNECT proxy support. Without these variables, the Google Ads gRPC client attempted a direct connection and failed with network errors.


## How
- This change adds the proxy variables required by gRPC-based clients, so the Google Ads connector consistently routes traffic through Squid in environments where direct egress is unavailable.
- Update Google Ads connector version and add the canonicalImageTag.


## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
