### PR TITLE
Skip proxy while building image for Python based connectors in CD pipeline

### DIFF
--- a/.github/actions/canonical-image-build-push/action.yml
+++ b/.github/actions/canonical-image-build-push/action.yml
@@ -134,6 +134,7 @@ runs:
         echo "🚀 Building $CONNECTOR with direct Docker buildx flow..."
         docker buildx build \
           --load \
+          --network=host \
           -f "$DOCKERFILE_PATH" \
           -t "$DEV_IMAGE" \
           --build-arg BASE_IMAGE="$CONNECTOR_BASE_IMAGE" \

--- a/.github/actions/canonical-image-build-push/action.yml
+++ b/.github/actions/canonical-image-build-push/action.yml
@@ -146,21 +146,6 @@ runs:
         fi
         echo "✅ Found built image: $DEV_IMAGE"
 
-        # Bake proxy env vars into the image as a thin layer on top,
-        # so they are present at runtime without interfering with the build.
-        if [ -n "$IMAGE_HTTP_PROXY" ]; then
-          echo "🔧 Injecting proxy env vars into image..."
-          docker build --load -t "$DEV_IMAGE" - <<EOF
-FROM $DEV_IMAGE
-ENV HTTP_PROXY=${IMAGE_HTTP_PROXY}
-ENV HTTPS_PROXY=${IMAGE_HTTPS_PROXY}
-ENV http_proxy=${IMAGE_HTTP_PROXY}
-ENV https_proxy=${IMAGE_HTTPS_PROXY}
-ENV grpc_proxy=${IMAGE_GRPC_PROXY}
-ENV GRPC_PROXY_EXP=${IMAGE_GRPC_PROXY_EXP}
-EOF
-        fi
-
         if grep -q "docker.io/airbyte/source-declarative-manifest" "$METADATAFILE"; then
           echo "🛠️ Detected manifest-only connector."
           IMAGE_USER="$({
@@ -173,6 +158,11 @@ EOF
             .github/scripts/build_custom_docker_image.sh "$CUSTOM_IMAGE" "$DEV_IMAGE"
           PUSH_IMAGE="$CUSTOM_IMAGE"
         else
+          # For non-manifest connectors, inject proxy env vars as a thin layer.
+          if [ -n "$IMAGE_HTTP_PROXY" ]; then
+            echo "🔧 Injecting proxy env vars into image..."
+            .github/scripts/build_custom_docker_image.sh "$DEV_IMAGE" "$DEV_IMAGE"
+          fi
           PUSH_IMAGE="$DEV_IMAGE"
         fi
 

--- a/.github/actions/canonical-image-build-push/action.yml
+++ b/.github/actions/canonical-image-build-push/action.yml
@@ -134,17 +134,10 @@ runs:
         echo "🚀 Building $CONNECTOR with direct Docker buildx flow..."
         docker buildx build \
           --load \
-          --network=host \
           -f "$DOCKERFILE_PATH" \
           -t "$DEV_IMAGE" \
           --build-arg BASE_IMAGE="$CONNECTOR_BASE_IMAGE" \
           --build-arg CONNECTOR_NAME="$CONNECTOR" \
-          --build-arg HTTP_PROXY="$IMAGE_HTTP_PROXY" \
-          --build-arg HTTPS_PROXY="$IMAGE_HTTPS_PROXY" \
-          --build-arg http_proxy="$IMAGE_HTTP_PROXY" \
-          --build-arg https_proxy="$IMAGE_HTTPS_PROXY" \
-          --build-arg grpc_proxy="$IMAGE_GRPC_PROXY" \
-          --build-arg GRPC_PROXY_EXP="$IMAGE_GRPC_PROXY_EXP" \
           "airbyte-integrations/connectors/$CONNECTOR"
 
         if ! docker images --format "{{.Repository}}:{{.Tag}}" | grep -q "$DEV_IMAGE"; then
@@ -152,6 +145,21 @@ runs:
           exit 1
         fi
         echo "✅ Found built image: $DEV_IMAGE"
+
+        # Bake proxy env vars into the image as a thin layer on top,
+        # so they are present at runtime without interfering with the build.
+        if [ -n "$IMAGE_HTTP_PROXY" ]; then
+          echo "🔧 Injecting proxy env vars into image..."
+          docker build --load -t "$DEV_IMAGE" - <<EOF
+FROM $DEV_IMAGE
+ENV HTTP_PROXY=${IMAGE_HTTP_PROXY}
+ENV HTTPS_PROXY=${IMAGE_HTTPS_PROXY}
+ENV http_proxy=${IMAGE_HTTP_PROXY}
+ENV https_proxy=${IMAGE_HTTPS_PROXY}
+ENV grpc_proxy=${IMAGE_GRPC_PROXY}
+ENV GRPC_PROXY_EXP=${IMAGE_GRPC_PROXY_EXP}
+EOF
+        fi
 
         if grep -q "docker.io/airbyte/source-declarative-manifest" "$METADATAFILE"; then
           echo "🛠️ Detected manifest-only connector."

--- a/.github/scripts/build_custom_docker_image.sh
+++ b/.github/scripts/build_custom_docker_image.sh
@@ -1,24 +1,31 @@
 #!/bin/bash
 # Build a custom docker image from another docker image (typically a dev image).
-# With that file, the image for the connector will have proxy settings defined.
-
+# Injects proxy env vars and optionally switches the image user.
+#
 # Usage: ./build_custom_docker_image.sh <custom-image-tag> <dev-image-tag>
+# Env vars read: IMAGE_HTTP_PROXY, IMAGE_HTTPS_PROXY, IMAGE_GRPC_PROXY,
+#                IMAGE_GRPC_PROXY_EXP, IMAGE_USER (optional)
 
 CUSTOM_IMAGE=$1
 BASE_IMAGE=$2
-IMAGE_USER=${IMAGE_USER:-root}
 
-echo "🚀 Setting up custom docker image: $CUSTOM_IMAGE from base image: $BASE_IMAGE using user: $IMAGE_USER..."
+echo "🚀 Setting up custom docker image: $CUSTOM_IMAGE from base image: $BASE_IMAGE..."
 
-docker build \
-  --build-arg BASE_IMAGE="$BASE_IMAGE" \
-  -t "$CUSTOM_IMAGE" \
-  - <<EOF
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
+# Build the Dockerfile content dynamically to avoid heredoc issues in CI YAML.
+DOCKERFILE_CONTENT="FROM ${BASE_IMAGE}
 ENV HTTP_PROXY=${IMAGE_HTTP_PROXY}
 ENV HTTPS_PROXY=${IMAGE_HTTPS_PROXY}
-USER ${IMAGE_USER}
-EOF
+ENV http_proxy=${IMAGE_HTTP_PROXY}
+ENV https_proxy=${IMAGE_HTTPS_PROXY}
+ENV grpc_proxy=${IMAGE_GRPC_PROXY}
+ENV GRPC_PROXY_EXP=${IMAGE_GRPC_PROXY_EXP}"
+
+# Only set USER if IMAGE_USER is explicitly provided.
+if [ -n "${IMAGE_USER:-}" ]; then
+  DOCKERFILE_CONTENT="${DOCKERFILE_CONTENT}
+USER ${IMAGE_USER}"
+fi
+
+echo "$DOCKERFILE_CONTENT" | docker build --load -t "$CUSTOM_IMAGE" -
 
 echo "✅ Custom image built: $CUSTOM_IMAGE from $BASE_IMAGE"

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
-    branches:
-      - master
 
 jobs:
   get_changed_directories_list:
@@ -24,8 +21,8 @@ jobs:
         id: detect-changes
         uses: ./.github/actions/detect-changes
         with:
-          base_commit: ${{ github.event.pull_request.base.sha }}
-          head_commit: ${{ github.event.pull_request.head.sha }}
+          base_commit: ${{ github.event.before }}
+          head_commit: ${{ github.sha }}
 
   build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/canonical_cd.yml
+++ b/.github/workflows/canonical_cd.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   get_changed_directories_list:
@@ -21,8 +24,8 @@ jobs:
         id: detect-changes
         uses: ./.github/actions/detect-changes
         with:
-          base_commit: ${{ github.event.before }}
-          head_commit: ${{ github.sha }}
+          base_commit: ${{ github.event.pull_request.base.sha }}
+          head_commit: ${{ github.event.pull_request.head.sha }}
 
   build_and_push:
     runs-on: ubuntu-latest

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerImageTag: 4.2.6-rc.2
   dockerRepository: airbyte/source-google-ads
-  canonicalImageTag: 4.2.6-canonical-1.3.0
+  canonicalImageTag: 4.2.6-canonical-1.3.1
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:
     - title: Release notes


### PR DESCRIPTION
## What
CD pipeline tries to use HTTP_PROXY while building a Docker image. However, the proxy is needed only after the build. This fix ensures that HTTP_PROXY is not used during the build phase.


## How
<!--
* Describe how code changes achieve the solution.
-->

## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
