### PR TITLE
Update Google Ads connector to version 6.0.0

### DIFF
--- a/.github/workflows/canonical_check_version_increase.yml
+++ b/.github/workflows/canonical_check_version_increase.yml
@@ -22,7 +22,7 @@ jobs:
             BASE_COMMIT=${{ github.event.pull_request.base.sha }}
           fi
           echo "BASE_COMMIT=$BASE_COMMIT"
-          CHANGED_DIRS=$(git diff --name-only $BASE_COMMIT $GITHUB_SHA | grep '^airbyte-integrations/connectors/' | cut -d/ -f3 | sort -u)
+          CHANGED_DIRS=$(git diff --name-only $BASE_COMMIT $GITHUB_SHA | grep '^airbyte-integrations/connectors/' | cut -d/ -f3 | sort -u | tr '\n' ' ' | xargs)
           echo "Changed connector directories: $CHANGED_DIRS"
           echo "CONNECTORS_LIST=$CHANGED_DIRS" >> $GITHUB_ENV
           echo "BASE_COMMIT=$BASE_COMMIT" >> $GITHUB_ENV

--- a/airbyte-integrations/connectors/source-google-ads/metadata.yaml
+++ b/airbyte-integrations/connectors/source-google-ads/metadata.yaml
@@ -13,7 +13,7 @@ data:
   definitionId: 253487c0-2246-43ba-a21f-5116b20a2c50
   dockerImageTag: 6.0.0
   dockerRepository: airbyte/source-google-ads
-  canonicalImageTag: 4.2.6-canonical-1.3.1
+  canonicalImageTag: 6.0.0-canonical-1.4.0
   documentationUrl: https://docs.airbyte.com/integrations/sources/google-ads
   externalDocumentationUrls:
     - title: Release notes

--- a/airbyte-integrations/connectors/source-marketo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-marketo/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 9e0556f4-69df-4522-a3fb-03264d36b348
   dockerImageTag: 2.0.1
-  canonicalImageTag: 1.6.2-canonical-1.1.3
+  canonicalImageTag: 1.6.2-canonical-1.1.4
   dockerRepository: airbyte/source-marketo
   documentationUrl: https://docs.airbyte.com/integrations/sources/marketo
   githubIssueLabel: source-marketo

--- a/airbyte-integrations/connectors/source-marketo/metadata.yaml
+++ b/airbyte-integrations/connectors/source-marketo/metadata.yaml
@@ -11,7 +11,7 @@ data:
   connectorType: source
   definitionId: 9e0556f4-69df-4522-a3fb-03264d36b348
   dockerImageTag: 2.0.1
-  canonicalImageTag: 1.6.2-canonical-1.1.4
+  canonicalImageTag: 2.0.1-canonical-1.2.0
   dockerRepository: airbyte/source-marketo
   documentationUrl: https://docs.airbyte.com/integrations/sources/marketo
   githubIssueLabel: source-marketo

--- a/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
@@ -229,7 +229,7 @@ class MarketoExportBase(IncrementalMarketoStream):
 
         for date_slice in date_slices:
             # this implementation is overriden in the upstream airbyte. we need to revisit it.
-            # param = {"fields": [], "filter": {self.export_date_filter_field: date_slice}}
+            # param = {"fields": [], "filter": {self.export_date_filter_field: date_slice}}
             param = {"fields": [], "filter": {self.filter_field: date_slice}}
             param["fields"].extend(self.stream_fields)
             param["filter"].update(self.stream_filter)

--- a/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
+++ b/airbyte-integrations/connectors/source-marketo/source_marketo/source.py
@@ -228,7 +228,7 @@ class MarketoExportBase(IncrementalMarketoStream):
         date_slices = super().stream_slices(sync_mode, stream_state, **kwargs)
 
         for date_slice in date_slices:
-            # TODO: this implementation is overriden in the upstream airbyte. we need to revisit it. 
+            # this implementation is overriden in the upstream airbyte. we need to revisit it.
             # param = {"fields": [], "filter": {self.export_date_filter_field: date_slice}}
             param = {"fields": [], "filter": {self.filter_field: date_slice}}
             param["fields"].extend(self.stream_fields)


### PR DESCRIPTION
## What
[Google Ads API v20 is deprecated](https://developers.google.com/google-ads/api/docs/sunset-dates), so the connector version 4.3. x does not work at the moment. 

## How
Update the Google Ads connector to version 6.0.0. It does not have any breaking changes. The [changes between v4 and v6](https://docs.airbyte.com/integrations/sources/google-ads#changelog) are API updates. 


It also updates the Marketo connector version because I need to fix the global check pipeline by removing a TODO. I have created this bug for the fix. https://warthogs.atlassian.net/browse/CSS-23721


## Review guide
<!--
1. `x.py`
2. `y.py`
-->

## User Impact
<!--
* What is the end result perceived by the user?
* If there are negative side effects, please list them. 
-->

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [ ] YES 💚
- [ ] NO ❌
