### PR TITLE
fix(source-discourse): add Retry-After on 429s and throttle under the API rate limit

### DIFF
--- a/airbyte-integrations/connectors/source-discourse/manifest.yaml
+++ b/airbyte-integrations/connectors/source-discourse/manifest.yaml
@@ -7,6 +7,18 @@ check:
   stream_names:
     - topics
 
+# Stay under Discourse's shared 60 req/min admin bucket instead of racing to a 429.
+api_budget:
+  type: HTTPAPIBudget
+  status_codes_for_ratelimit_hit:
+    - 429
+  policies:
+    - type: MovingWindowCallRatePolicy
+      rates:
+        - limit: 50
+          interval: PT1M
+      matchers: []
+
 definitions:
   streams:
     topics:
@@ -117,6 +129,16 @@ definitions:
         type: RequestOption
         field_name: Api-Key
         inject_into: header
+    error_handler:
+      type: DefaultErrorHandler
+      max_retries: 10
+      backoff_strategies:
+        # Leverage on Discourse's Retry-After on 429s.
+        - type: WaitTimeFromHeader
+          header: Retry-After
+          max_waiting_time_in_seconds: 180
+        - type: ExponentialBackoffStrategy
+          factor: 5
 
 streams:
   - $ref: "#/definitions/streams/topics"

--- a/airbyte-integrations/connectors/source-discourse/metadata.yaml
+++ b/airbyte-integrations/connectors/source-discourse/metadata.yaml
@@ -13,8 +13,8 @@ data:
     baseImage: docker.io/airbyte/source-declarative-manifest:6.60.16@sha256:b8126848437ec5a6cff05fb4796fd775450b83e57925674d856a1838a390a28c
   connectorSubtype: api
   connectorType: source
-  dockerImageTag: 0.1.0
-  canonicalImageTag: 0.1.0
+  dockerImageTag: 0.1.1
+  canonicalImageTag: 0.1.1
   dockerRepository: airbyte/source-discourse
   githubIssueLabel: source-discourse
   icon: icon.svg

--- a/docs/integrations/sources/discourse.md
+++ b/docs/integrations/sources/discourse.md
@@ -49,6 +49,7 @@ If there are more endpoints you'd like Airbyte to support, please [create an iss
 
 | Version | Date       | Pull Request                                       | Subject                                            |
 | :------ | :--------- | :------------------------------------------------- | :------------------------------------------------- |
+| 0.1.1   | 2026-07-21 | [#83](https://github.com/canonical/airbyte/pull/#83) | Leverage on Discourse's Retry-After on 429s and throttle requests under the API rate limit |
 | 0.1.0   | 2025-09-09 | [#31](https://github.com/canonical/airbyte/pull/#31) | Initial release of Discourse connector for Airbyte |
 
 </details>


### PR DESCRIPTION
## What
The Discourse connection fails with `RateLimitBackoffException: Too many requests`. The connector ignored Discourse's `Retry-After` header and fell back to the standard exponential backoff that gives up before the 60 req/min bucket resets.

## How
In manifest.yaml:
- Added an `error_handler` that honors the `Retry-After` header on 429s (`WaitTimeFromHeader`), with an exponential fallback and `max_retries: 10`.
- Added an `api_budget` (`MovingWindowCallRatePolicy`, 50/min) to proactively stay under Discourse's shared admin bucket instead of racing to a 429.

## Review guide
1. `airbyte-integrations/connectors/source-discourse/manifest.yaml`: the fix (`error_handler` + `api_budget`)
2. `airbyte-integrations/connectors/source-discourse/metadata.yaml`: version bump to `0.1.1`
3. `docs/integrations/sources/discourse.md`: changelog

## User Impact
Syncs recover from rate-limit responses instead of failing, and generate fewer 429s. No config or schema changes.

## Can this PR be safely reverted and rolled back?
<!--
* If unsure, leave it blank.
-->
- [x] YES 💚
- [ ] NO ❌
