### PR TITLE
feat(source-skillsbase): add hire_date field

### DIFF
--- a/airbyte-integrations/connectors/source-skillsbase/Makefile
+++ b/airbyte-integrations/connectors/source-skillsbase/Makefile
@@ -23,7 +23,7 @@ CONFIG     := /work/secrets/config.json
 INVALID    := /work/integration_tests/invalid_config.json
 CATALOG    := /work/integration_tests/configured_catalog.json
 QA_CATALOG := /work/integration_tests/qualifications_catalog.json
-
+PEOPLE_CATALOG := /work/integration_tests/people_catalog.json
 PERSIST := scripts/persist_token.sh secrets/config.json
 
 .PHONY: help build spec check check-invalid discover read read-qualifications \
@@ -72,6 +72,9 @@ read:  ## Read all streams using configured_catalog.json. Persists the refreshed
 
 read-qualifications:  ## Read only qualifications_assignments (smallest stream, ~15 records on sandbox). Persists the refreshed token.
 	$(DOCKER_RUN) read --config $(CONFIG) --catalog $(QA_CATALOG) | $(PERSIST)
+
+read-people:  ## Read only people_assignments (smallest stream, ~15 records on sandbox). Persists the refreshed token.
+	$(DOCKER_RUN) read --config $(CONFIG) --catalog $(PEOPLE_CATALOG) | $(PERSIST)
 
 test-acceptance: build  ## Run Connector Acceptance Tests via the official Docker image (rebuilds image and pre-warms token first).
 	# Pre-warm the token cache so parallel CAT containers reuse it instead of

--- a/airbyte-integrations/connectors/source-skillsbase/integration_tests/people_catalog.json
+++ b/airbyte-integrations/connectors/source-skillsbase/integration_tests/people_catalog.json
@@ -1,0 +1,15 @@
+{
+  "streams": [
+    {
+      "stream": {
+        "name": "people",
+        "json_schema": {},
+        "supported_sync_modes": ["full_refresh"],
+        "source_defined_primary_key": [["id"]],
+        "source_defined_cursor": true
+      },
+      "sync_mode": "full_refresh",
+      "destination_sync_mode": "overwrite"
+    }
+  ]
+}

--- a/airbyte-integrations/connectors/source-skillsbase/manifest.yaml
+++ b/airbyte-integrations/connectors/source-skillsbase/manifest.yaml
@@ -129,6 +129,8 @@ streams:
             type: [string, "null"]
           first_name:
             type: [string, "null"]
+          hire_date:
+            type: [string, "null"]
           last_login:
             type: [string, "null"]
           location_id:

--- a/airbyte-integrations/connectors/source-skillsbase/metadata.yaml
+++ b/airbyte-integrations/connectors/source-skillsbase/metadata.yaml
@@ -17,8 +17,8 @@ data:
   connectorSubtype: api
   connectorType: source
   definitionId: e63482c9-b017-425b-9d18-f08410d5db32
-  dockerImageTag: 1.0.0
-  canonicalImageTag: 1.0.0-canonical-1.0.0
+  dockerImageTag: 1.1.0
+  canonicalImageTag: 1.1.0-canonical-1.0.0
   dockerRepository: airbyte/source-skillsbase
   githubIssueLabel: source-skillsbase
   icon: icon.svg


### PR DESCRIPTION
## What
Adds the newly-introduced `hire_date` field to the Skills Base `people` stream so it is discovered and synced to the destination.

## Review guide
1. `manifest.yaml`: the `hire_date` property under the `people` stream schema.
2. `integration_tests/people_catalog.json`: new people-only catalog.
3. `Makefile`: `read-people` target + `PEOPLE_CATALOG` variable.

## Can this PR be safely reverted and rolled back?
- [x] YES 💚
- [ ] NO ❌